### PR TITLE
Parallelize test runs via test-splitting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
 
 jobs:
   test:
-    parallelism: 1
+    parallelism: 2
     executor: py-3-10
     steps:
       - checkout
@@ -21,7 +21,12 @@ jobs:
       - run:
           name: Run unit tests
           command: |
-            poetry run pytest .
+            TEST_FILES=$(circleci tests glob "tests/**/test_*.py" | circleci tests split --split-by=timings)
+
+            # debug
+            echo "test files to run:\n\n$TEST_FILES\n"
+
+            poetry run pytest $TEST_FILES
           environment:
             PYTHONPATH: src
       - store_test_results:


### PR DESCRIPTION
With this PR, we run our tests in parallel via [CircleCI's test-splitting feature](https://circleci.com/docs/parallelism-faster-jobs).

In particular, we split by timing data.

In this contrived example, we can argue that test-splitting may not make sense since:

- number of test files are few (2), and test cases run fast
- time taken for each parallel node to setup (e.g., installing dependencies) and teardown for tests > time taken to run split test sets
